### PR TITLE
Structure Fix

### DIFF
--- a/src/main/java/dev/austinbarnes/problemsolving/pickingnumbers/PickingNumbers.java
+++ b/src/main/java/dev/austinbarnes/problemsolving/pickingnumbers/PickingNumbers.java
@@ -1,4 +1,4 @@
-package dev.austinbarnes.problemsolving;
+package dev.austinbarnes.problemsolving.pickingnumbers;
 
 import java.io.*;
 import java.util.*;


### PR DESCRIPTION
Place PickingNumbers in its own package and will continue to do so for each new problem moving forward.
This removes the conflict that stems from HackerRank using a Result class in each problem.